### PR TITLE
Implement responsive Salah Home Screen widgets

### DIFF
--- a/Salah.xcodeproj/project.pbxproj
+++ b/Salah.xcodeproj/project.pbxproj
@@ -3,10 +3,13 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0C7044AE3017C6B800277BD4 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C7044AD3017C6B800277BD4 /* WidgetKit.framework */; };
+		0C7044B03017C6B800277BD4 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C7044AF3017C6B800277BD4 /* SwiftUI.framework */; };
+		0C7044C23017C6BA00277BD4 /* SalahWidgetsExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 0C7044AB3017C6B800277BD4 /* SalahWidgetsExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		5A8F54892B87696500ED1BFC /* Location/districts.json in Resources */ = {isa = PBXBuildFile; fileRef = 5A8F54882B87696500ED1BFC /* Location/districts.json */; };
 		5AA6AB572B81E90900E2A7DB /* SalahApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA6AB562B81E90900E2A7DB /* SalahApp.swift */; };
 		5AA6AB5B2B81E90A00E2A7DB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5AA6AB5A2B81E90A00E2A7DB /* Assets.xcassets */; };
@@ -28,6 +31,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		0C7044BF3017C6BA00277BD4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5AA6AB4B2B81E90900E2A7DB /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0C7044AA3017C6B800277BD4;
+			remoteInfo = SalahWidgetsExtension;
+		};
 		D60000000000000000000001 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 5AA6AB4B2B81E90900E2A7DB /* Project object */;
@@ -44,8 +54,25 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		0C7044C13017C6BA00277BD4 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				0C7044C23017C6BA00277BD4 /* SalahWidgetsExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		0C6F31013013EF7F0065F050 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .swiftlint.yml; sourceTree = "<group>"; };
+		0C7044AB3017C6B800277BD4 /* SalahWidgetsExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = SalahWidgetsExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		0C7044AD3017C6B800277BD4 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		0C7044AF3017C6B800277BD4 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		5A8F54882B87696500ED1BFC /* Location/districts.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Location/districts.json; sourceTree = "<group>"; };
 		5AA6AB532B81E90900E2A7DB /* Salah.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Salah.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5AA6AB562B81E90900E2A7DB /* SalahApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SalahApp.swift; sourceTree = "<group>"; };
@@ -69,7 +96,30 @@
 		D40000000000000000000004 /* SalahUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SalahUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		0C7044C53017C6BA00277BD4 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 0C7044AA3017C6B800277BD4 /* SalahWidgetsExtension */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		0C7044B13017C6B800277BD4 /* SalahWidgets */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (0C7044C53017C6BA00277BD4 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = SalahWidgets; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
+		0C7044A83017C6B800277BD4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0C7044B03017C6B800277BD4 /* SwiftUI.framework in Frameworks */,
+				0C7044AE3017C6B800277BD4 /* WidgetKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5AA6AB502B81E90900E2A7DB /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -94,6 +144,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0C7044AC3017C6B800277BD4 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				0C7044AD3017C6B800277BD4 /* WidgetKit.framework */,
+				0C7044AF3017C6B800277BD4 /* SwiftUI.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		5AA6AB4A2B81E90900E2A7DB = {
 			isa = PBXGroup;
 			children = (
@@ -101,6 +160,8 @@
 				5AA6AB552B81E90900E2A7DB /* Salah */,
 				D80000000000000000000001 /* SalahTests */,
 				D80000000000000000000002 /* SalahUITests */,
+				0C7044B13017C6B800277BD4 /* SalahWidgets */,
+				0C7044AC3017C6B800277BD4 /* Frameworks */,
 				5AA6AB542B81E90900E2A7DB /* Products */,
 			);
 			sourceTree = "<group>";
@@ -111,6 +172,7 @@
 				5AA6AB532B81E90900E2A7DB /* Salah.app */,
 				D40000000000000000000003 /* SalahTests.xctest */,
 				D40000000000000000000004 /* SalahUITests.xctest */,
+				0C7044AB3017C6B800277BD4 /* SalahWidgetsExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -205,6 +267,28 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		0C7044AA3017C6B800277BD4 /* SalahWidgetsExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0C7044C63017C6BA00277BD4 /* Build configuration list for PBXNativeTarget "SalahWidgetsExtension" */;
+			buildPhases = (
+				0C7044A73017C6B800277BD4 /* Sources */,
+				0C7044A83017C6B800277BD4 /* Frameworks */,
+				0C7044A93017C6B800277BD4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				0C7044B13017C6B800277BD4 /* SalahWidgets */,
+			);
+			name = SalahWidgetsExtension;
+			packageProductDependencies = (
+			);
+			productName = SalahWidgetsExtension;
+			productReference = 0C7044AB3017C6B800277BD4 /* SalahWidgetsExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		5AA6AB522B81E90900E2A7DB /* Salah */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 5AA6AB612B81E90A00E2A7DB /* Build configuration list for PBXNativeTarget "Salah" */;
@@ -213,10 +297,12 @@
 				5AA6AB4F2B81E90900E2A7DB /* Sources */,
 				5AA6AB502B81E90900E2A7DB /* Frameworks */,
 				5AA6AB512B81E90900E2A7DB /* Resources */,
+				0C7044C13017C6BA00277BD4 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				0C7044C03017C6BA00277BD4 /* PBXTargetDependency */,
 			);
 			name = Salah;
 			productName = Salah;
@@ -266,9 +352,12 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1520;
+				LastSwiftUpdateCheck = 2600;
 				LastUpgradeCheck = 1520;
 				TargetAttributes = {
+					0C7044AA3017C6B800277BD4 = {
+						CreatedOnToolsVersion = 26.0.1;
+					};
 					5AA6AB522B81E90900E2A7DB = {
 						CreatedOnToolsVersion = 15.2;
 					};
@@ -298,11 +387,19 @@
 				5AA6AB522B81E90900E2A7DB /* Salah */,
 				D90000000000000000000001 /* SalahTests */,
 				D90000000000000000000002 /* SalahUITests */,
+				0C7044AA3017C6B800277BD4 /* SalahWidgetsExtension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		0C7044A93017C6B800277BD4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5AA6AB512B81E90900E2A7DB /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -352,6 +449,13 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		0C7044A73017C6B800277BD4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5AA6AB4F2B81E90900E2A7DB /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -390,6 +494,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		0C7044C03017C6BA00277BD4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0C7044AA3017C6B800277BD4 /* SalahWidgetsExtension */;
+			targetProxy = 0C7044BF3017C6BA00277BD4 /* PBXContainerItemProxy */;
+		};
 		DD0000000000000000000001 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 5AA6AB522B81E90900E2A7DB /* Salah */;
@@ -403,6 +512,68 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		0C7044C33017C6BA00277BD4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = PXF7DUQPQ9;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SalahWidgets/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = SalahWidgets;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = MahiAlJawad.SalahiOS.SalahWidgets;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		0C7044C43017C6BA00277BD4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = PXF7DUQPQ9;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SalahWidgets/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = SalahWidgets;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = MahiAlJawad.SalahiOS.SalahWidgets;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		5AA6AB5F2B81E90A00E2A7DB /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -643,6 +814,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		0C7044C63017C6BA00277BD4 /* Build configuration list for PBXNativeTarget "SalahWidgetsExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0C7044C33017C6BA00277BD4 /* Debug */,
+				0C7044C43017C6BA00277BD4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		5AA6AB4E2B81E90900E2A7DB /* Build configuration list for PBXProject "Salah" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Salah.xcodeproj/project.pbxproj
+++ b/Salah.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		D2000000000000000000000B /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = D1000000000000000000000B /* Localizable.xcstrings */; };
 		D2000000000000000000000C /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D1000000000000000000000C /* PrivacyInfo.xcprivacy */; };
 		D2000000000000000000000D /* UITestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000000000000000000000D /* UITestSupport.swift */; };
+		D2000000000000000000000E /* WidgetSharedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000000000000000000000E /* WidgetSharedData.swift */; };
+		D2000000000000000000000F /* WidgetDataPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000000000000000000000F /* WidgetDataPublisher.swift */; };
 		D50000000000000000000001 /* SalahDomainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40000000000000000000001 /* SalahDomainTests.swift */; };
 		D50000000000000000000002 /* SalahUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40000000000000000000002 /* SalahUITests.swift */; };
 /* End PBXBuildFile section */
@@ -73,6 +75,8 @@
 		0C7044AB3017C6B800277BD4 /* SalahWidgetsExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = SalahWidgetsExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		0C7044AD3017C6B800277BD4 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		0C7044AF3017C6B800277BD4 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
+		0C7044C73017C8F900277BD4 /* Salah.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Salah.entitlements; sourceTree = "<group>"; };
+		0C7044C83017C92200277BD4 /* SalahWidgetsExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SalahWidgetsExtension.entitlements; sourceTree = "<group>"; };
 		5A8F54882B87696500ED1BFC /* Location/districts.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Location/districts.json; sourceTree = "<group>"; };
 		5AA6AB532B81E90900E2A7DB /* Salah.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Salah.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5AA6AB562B81E90900E2A7DB /* SalahApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SalahApp.swift; sourceTree = "<group>"; };
@@ -90,6 +94,8 @@
 		D1000000000000000000000B /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		D1000000000000000000000C /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		D1000000000000000000000D /* UITestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestSupport.swift; sourceTree = "<group>"; };
+		D1000000000000000000000E /* WidgetSharedData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WidgetSharedData.swift; path = SalahWidgets/WidgetSharedData.swift; sourceTree = "<group>"; };
+		D1000000000000000000000F /* WidgetDataPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetDataPublisher.swift; sourceTree = "<group>"; };
 		D40000000000000000000001 /* SalahDomainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SalahDomainTests.swift; sourceTree = "<group>"; };
 		D40000000000000000000002 /* SalahUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SalahUITests.swift; sourceTree = "<group>"; };
 		D40000000000000000000003 /* SalahTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SalahTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -156,6 +162,8 @@
 		5AA6AB4A2B81E90900E2A7DB = {
 			isa = PBXGroup;
 			children = (
+				0C7044C83017C92200277BD4 /* SalahWidgetsExtension.entitlements */,
+				D1000000000000000000000E /* WidgetSharedData.swift */,
 				0C6F31013013EF7F0065F050 /* .swiftlint.yml */,
 				5AA6AB552B81E90900E2A7DB /* Salah */,
 				D80000000000000000000001 /* SalahTests */,
@@ -180,6 +188,8 @@
 		5AA6AB552B81E90900E2A7DB /* Salah */ = {
 			isa = PBXGroup;
 			children = (
+				0C7044C73017C8F900277BD4 /* Salah.entitlements */,
+				D1000000000000000000000F /* WidgetDataPublisher.swift */,
 				5AA6AB562B81E90900E2A7DB /* SalahApp.swift */,
 				D30000000000000000000001 /* App */,
 				D30000000000000000000002 /* Core */,
@@ -472,6 +482,8 @@
 				D20000000000000000000008 /* TodayCalendar.swift in Sources */,
 				D20000000000000000000009 /* TrackerHistory.swift in Sources */,
 				D2000000000000000000000A /* MoreSettings.swift in Sources */,
+				D2000000000000000000000E /* WidgetSharedData.swift in Sources */,
+				D2000000000000000000000F /* WidgetDataPublisher.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -517,6 +529,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = SalahWidgetsExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = PXF7DUQPQ9;
@@ -531,7 +544,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = MahiAlJawad.SalahiOS.SalahWidgets;
+				PRODUCT_BUNDLE_IDENTIFIER = MahiAlJawad.SalahiOSNew.SalahWidgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -548,6 +561,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = SalahWidgetsExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = PXF7DUQPQ9;
@@ -562,7 +576,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = MahiAlJawad.SalahiOS.SalahWidgets;
+				PRODUCT_BUNDLE_IDENTIFIER = MahiAlJawad.SalahiOSNew.SalahWidgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -698,9 +712,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Salah/Salah.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = PXF7DUQPQ9;
+				DEVELOPMENT_TEAM = GRW9NYZR4G;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -715,7 +730,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = MahiAlJawad.SalahiOS;
+				PRODUCT_BUNDLE_IDENTIFIER = MahiAlJawad.SalahiOSNew;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -728,9 +743,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Salah/Salah.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = PXF7DUQPQ9;
+				DEVELOPMENT_TEAM = GRW9NYZR4G;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -745,7 +761,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = MahiAlJawad.SalahiOS;
+				PRODUCT_BUNDLE_IDENTIFIER = MahiAlJawad.SalahiOSNew;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/Salah/Features/TodayCalendar.swift
+++ b/Salah/Features/TodayCalendar.swift
@@ -32,16 +32,28 @@ final class TodayViewModel {
                 policy: policy
             )
             let priorLocalDay = day.adding(days: -1, in: location.timeZone)
+            let tomorrowLocalDay = day.adding(days: 1, in: location.timeZone)
             async let prior = try? repository.day(
                 for: PrayerTimesQuery(day: priorLocalDay, location: location, settings: calculation),
                 location: location,
                 policy: .cacheFirst
             )
+            async let tomorrow = try? repository.day(
+                for: PrayerTimesQuery(day: tomorrowLocalDay, location: location, settings: calculation),
+                location: location,
+                policy: .cacheFirst
+            )
             let loaded = try await main
             let priorLoaded = await prior
+            let tomorrowLoaded = await tomorrow
             guard requestID == token else { return }
             previousDay = priorLoaded?.value
             completed = (try? trackingRepository.completedPrayerTypes(on: day)) ?? []
+            WidgetDataPublisher.save(
+                prayerDay: loaded.value,
+                completed: completed,
+                tomorrowFajr: tomorrowLoaded?.value.window(for: .fajr)?.start
+            )
             state = loaded.isStale
                 ? .offline(loaded.value, lastUpdated: loaded.value.fetchedAt)
                 : .loaded(loaded.value, source: loaded.source)
@@ -59,6 +71,7 @@ final class TodayViewModel {
         do {
             try trackingRepository.setCompleted(newValue, prayer: prayer, day: day, timeZone: timeZone, source: source)
             if newValue { completed.insert(prayer) } else { completed.remove(prayer) }
+            WidgetDataPublisher.updateCompletion(prayer: prayer, day: day, completed: newValue)
         } catch { }
     }
 }
@@ -588,6 +601,7 @@ struct PrayerCalendarView: View {
                             ) {
                                 let current = (try? container.trackingRepository.completedPrayerTypes(on: selected.localDay).contains(prayer)) ?? false
                                 try? container.trackingRepository.setCompleted(!current, prayer: prayer, day: selected.localDay, timeZone: selected.timeZone, source: "calendar")
+                                WidgetDataPublisher.updateCompletion(prayer: prayer, day: selected.localDay, completed: !current)
                             }
                         }
                     }

--- a/Salah/Features/TrackerHistory.swift
+++ b/Salah/Features/TrackerHistory.swift
@@ -39,6 +39,11 @@ final class TrackerViewModel {
         do {
             try repository.setCompleted(value, prayer: prayer, day: selectedDay, timeZone: settings.location.timeZone, source: "tracker")
             if value { completed.insert(prayer) } else { completed.remove(prayer) }
+            WidgetDataPublisher.updateCompletion(
+                prayer: prayer,
+                day: selectedDay,
+                completed: value
+            )
             lastChanged = prayer
             errorMessage = nil
         } catch {

--- a/Salah/Salah.entitlements
+++ b/Salah/Salah.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.mahiJawad_tanjimShakib.SalahiOS</string>
+	</array>
+</dict>
+</plist>

--- a/Salah/WidgetDataPublisher.swift
+++ b/Salah/WidgetDataPublisher.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+enum WidgetDataPublisher {
+    static func save(
+        prayerDay: PrayerDay,
+        completed: Set<PrayerType>,
+        tomorrowFajr: Date? = nil
+    ) {
+        let today = LocalDay(.now, timeZone: prayerDay.timeZone)
+        guard prayerDay.localDay == today else { return }
+
+        let now = Date()
+        let nextPrayerType = prayerDay.windows.first { $0.start > now }?.prayer
+            ?? (tomorrowFajr == nil ? nil : .fajr)
+
+        let prayerItems = prayerDay.windows.map { window in
+            WidgetPrayer(
+                name: window.prayer.title,
+                time: window.start,
+                symbolName: window.prayer.symbol,
+                completed: completed.contains(window.prayer),
+                isNext: window.prayer == nextPrayerType
+            )
+        }
+
+        let sunriseItem = WidgetPrayer(
+            name: "Sunrise",
+            time: prayerDay.sunrise,
+            symbolName: "sunrise.fill",
+            completed: false,
+            isNext: false
+        )
+        let scheduleItems = prayerItems.reduce(into: [WidgetPrayer]()) { result, item in
+            result.append(item)
+            if item.name == PrayerType.fajr.title {
+                result.append(sunriseItem)
+            }
+        }
+
+        let tomorrowItem = tomorrowFajr.map {
+            WidgetPrayer(
+                name: PrayerType.fajr.title,
+                time: $0,
+                symbolName: PrayerType.fajr.symbol,
+                completed: false,
+                isNext: nextPrayerType == .fajr && prayerDay.windows.allSatisfy { $0.start <= now }
+            )
+        }
+
+        let nextPrayer = scheduleItems.first(where: \.isNext) ?? tomorrowItem
+        let snapshot = WidgetSnapshot(
+            updatedAt: .now,
+            localDayKey: prayerDay.localDay.key,
+            gregorianSummary: prayerDay.gregorianSummary,
+            hijriSummary: prayerDay.hijriSummary,
+            timeZoneIdentifier: prayerDay.timeZoneIdentifier,
+            prayers: scheduleItems,
+            nextPrayer: nextPrayer,
+            tomorrowFajr: tomorrowItem
+        )
+
+        WidgetDataStore.save(snapshot)
+    }
+
+    static func updateCompletion(
+        prayer: PrayerType,
+        day: LocalDay,
+        completed: Bool
+    ) {
+        guard let snapshot = WidgetDataStore.load(), snapshot.localDayKey == day.key else { return }
+
+        let updatedPrayers = snapshot.prayers.map { item in
+            item.name == prayer.title
+                ? WidgetPrayer(
+                    name: item.name,
+                    time: item.time,
+                    symbolName: item.symbolName,
+                    completed: completed,
+                    isNext: item.isNext
+                )
+                : item
+        }
+        let updatedNextPrayer = snapshot.nextPrayer.map { item in
+            item.name == prayer.title
+                ? WidgetPrayer(
+                    name: item.name,
+                    time: item.time,
+                    symbolName: item.symbolName,
+                    completed: completed,
+                    isNext: item.isNext
+                )
+                : item
+        }
+
+        let updated = WidgetSnapshot(
+            updatedAt: .now,
+            localDayKey: snapshot.localDayKey,
+            gregorianSummary: snapshot.gregorianSummary,
+            hijriSummary: snapshot.hijriSummary,
+            timeZoneIdentifier: snapshot.timeZoneIdentifier,
+            prayers: updatedPrayers,
+            nextPrayer: updatedNextPrayer,
+            tomorrowFajr: snapshot.tomorrowFajr
+        )
+
+        WidgetDataStore.save(updated)
+    }
+}

--- a/SalahWidgets/AppIntent.swift
+++ b/SalahWidgets/AppIntent.swift
@@ -1,0 +1,18 @@
+//
+//  AppIntent.swift
+//  SalahWidgets
+//
+//  Created by Kazi Tanjim Shakib on 27/7/26.
+//
+
+import WidgetKit
+import AppIntents
+
+struct ConfigurationAppIntent: WidgetConfigurationIntent {
+    static var title: LocalizedStringResource { "Configuration" }
+    static var description: IntentDescription { "This is an example widget." }
+
+    // An example configurable parameter.
+    @Parameter(title: "Favorite Emoji", default: "😃")
+    var favoriteEmoji: String
+}

--- a/SalahWidgets/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/SalahWidgets/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SalahWidgets/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/SalahWidgets/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SalahWidgets/Assets.xcassets/Contents.json
+++ b/SalahWidgets/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SalahWidgets/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/SalahWidgets/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SalahWidgets/Info.plist
+++ b/SalahWidgets/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/SalahWidgets/SalahWidgets.swift
+++ b/SalahWidgets/SalahWidgets.swift
@@ -10,25 +10,33 @@ import SwiftUI
 
 struct Provider: AppIntentTimelineProvider {
     func placeholder(in context: Context) -> SimpleEntry {
-        SimpleEntry(date: Date(), configuration: ConfigurationAppIntent())
+        SimpleEntry(date: Date(), configuration: ConfigurationAppIntent(), snapshot: nil)
     }
 
     func snapshot(for configuration: ConfigurationAppIntent, in context: Context) async -> SimpleEntry {
-        SimpleEntry(date: Date(), configuration: configuration)
+        SimpleEntry(
+            date: .now,
+            configuration: configuration,
+            snapshot: WidgetDataStore.load()?.snapshot(at: .now)
+        )
     }
     
     func timeline(for configuration: ConfigurationAppIntent, in context: Context) async -> Timeline<SimpleEntry> {
-        var entries: [SimpleEntry] = []
+        let now = Date()
+        let snapshot = WidgetDataStore.load()?.snapshot(at: now)
+        let periodicRefresh = now.addingTimeInterval(15 * 60)
+        let prayerTransition = snapshot?.nextPrayer?.time.addingTimeInterval(1)
+        let refreshDate = min(
+            prayerTransition ?? periodicRefresh,
+            periodicRefresh
+        )
+        let entry = SimpleEntry(
+            date: now,
+            configuration: configuration,
+            snapshot: snapshot
+        )
 
-        // Generate a timeline consisting of five entries an hour apart, starting from the current date.
-        let currentDate = Date()
-        for hourOffset in 0 ..< 5 {
-            let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate)!
-            let entry = SimpleEntry(date: entryDate, configuration: configuration)
-            entries.append(entry)
-        }
-
-        return Timeline(entries: entries, policy: .atEnd)
+        return Timeline(entries: [entry], policy: .after(refreshDate))
     }
 
 //    func relevances() async -> WidgetRelevances<ConfigurationAppIntent> {
@@ -39,19 +47,208 @@ struct Provider: AppIntentTimelineProvider {
 struct SimpleEntry: TimelineEntry {
     let date: Date
     let configuration: ConfigurationAppIntent
+    let snapshot: WidgetSnapshot?
 }
 
 struct SalahWidgetsEntryView : View {
     var entry: Provider.Entry
+    @Environment(\.widgetFamily) private var family
 
     var body: some View {
-        VStack {
-            Text("Time:")
-            Text(entry.date, style: .time)
-
-            Text("Favorite Emoji:")
-            Text(entry.configuration.favoriteEmoji)
+        Group {
+            switch family {
+            case .systemMedium:
+                MediumWidgetView(snapshot: entry.snapshot)
+            default:
+                SmallWidgetView(snapshot: entry.snapshot)
+            }
         }
+        .containerBackground(for: .widget) {
+            WidgetTheme.background
+        }
+    }
+}
+
+private enum WidgetTheme {
+    static let background = LinearGradient(
+        colors: [Color(red: 0.035, green: 0.075, blue: 0.11), Color(red: 0.02, green: 0.04, blue: 0.065)],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+    static let panel = Color.white.opacity(0.055)
+    static let primary = Color.white
+    static let secondary = Color.white.opacity(0.62)
+    static let muted = Color.white.opacity(0.36)
+    static let accent = Color(red: 0.29, green: 0.82, blue: 0.75)
+    static let divider = Color.white.opacity(0.13)
+}
+
+private enum WidgetTimeFormatter {
+    static func time(_ date: Date, timezoneIdentifier: String) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = .current
+        formatter.timeZone = TimeZone(identifier: timezoneIdentifier) ?? .current
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+}
+
+private struct SmallWidgetView: View {
+    let snapshot: WidgetSnapshot?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Image(systemName: "moon.stars.fill")
+                    .font(.title3)
+                    .foregroundStyle(WidgetTheme.accent)
+                Spacer()
+                Image(systemName: "sparkles")
+                    .font(.caption)
+                    .foregroundStyle(WidgetTheme.muted)
+            }
+
+            Spacer(minLength: 8)
+
+            if let snapshot, let next = snapshot.nextPrayer {
+                Text("NEXT PRAYER")
+                    .font(.caption2.weight(.semibold))
+                    .tracking(1.1)
+                    .foregroundStyle(WidgetTheme.accent)
+
+                Text(next.name)
+                    .font(.system(size: 27, weight: .medium, design: .serif))
+                    .foregroundStyle(WidgetTheme.primary)
+                    .lineLimit(1)
+
+                HStack(alignment: .firstTextBaseline, spacing: 4) {
+                    Text("in")
+                        .foregroundStyle(WidgetTheme.accent)
+                    Text(next.time, style: .timer)
+                        .foregroundStyle(WidgetTheme.accent)
+                        .monospacedDigit()
+                }
+                .font(.subheadline.weight(.semibold))
+
+                Spacer(minLength: 8)
+                Rectangle()
+                    .fill(WidgetTheme.divider)
+                    .frame(height: 1)
+                HStack(spacing: 5) {
+                    Image(systemName: "clock")
+                    Text(WidgetTimeFormatter.time(next.time, timezoneIdentifier: snapshot.timeZoneIdentifier))
+                }
+                .font(.caption)
+                .foregroundStyle(WidgetTheme.secondary)
+                .padding(.top, 8)
+            } else {
+                Text("Open Salah to load prayer times")
+                    .font(.caption)
+                    .foregroundStyle(WidgetTheme.secondary)
+                    .multilineTextAlignment(.leading)
+            }
+        }
+        .padding(16)
+    }
+}
+
+private struct MediumWidgetView: View {
+    let snapshot: WidgetSnapshot?
+
+    var body: some View {
+        HStack(spacing: 14) {
+            if let snapshot, let next = snapshot.nextPrayer {
+                VStack(alignment: .leading, spacing: 0) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "calendar")
+                            .foregroundStyle(WidgetTheme.accent)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(snapshot.gregorianSummary)
+                                .font(.caption.weight(.semibold))
+                            Text(snapshot.hijriSummary)
+                                .font(.caption2)
+                                .foregroundStyle(WidgetTheme.secondary)
+                        }
+                    }
+
+                    Spacer(minLength: 12)
+
+                    Text("NEXT PRAYER")
+                        .font(.caption2.weight(.semibold))
+                        .tracking(1.1)
+                        .foregroundStyle(WidgetTheme.accent)
+                    Text(next.name)
+                        .font(.system(size: 36, weight: .medium, design: .serif))
+                        .foregroundStyle(WidgetTheme.primary)
+                        .lineLimit(1)
+                    HStack(alignment: .firstTextBaseline, spacing: 4) {
+                        Text("in")
+                        Text(next.time, style: .timer)
+                            .monospacedDigit()
+                    }
+                    .font(.headline.weight(.semibold))
+                    .foregroundStyle(WidgetTheme.accent)
+
+                    Spacer(minLength: 8)
+
+                    HStack(spacing: 8) {
+                        Image(systemName: "moon.stars.fill")
+                            .font(.title2)
+                        Image(systemName: "building.columns.fill")
+                            .font(.title3)
+                            .opacity(0.35)
+                    }
+                    .foregroundStyle(WidgetTheme.accent.opacity(0.7))
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                Rectangle()
+                    .fill(WidgetTheme.divider)
+                    .frame(width: 1)
+
+                VStack(spacing: 0) {
+                    HStack(spacing: 5) {
+                        Spacer()
+                        Text("Updated (WidgetTimeFormatter.time(snapshot.updatedAt, timezoneIdentifier: snapshot.timeZoneIdentifier))")
+                        Image(systemName: "arrow.clockwise")
+                    }
+                    .font(.caption2)
+                    .foregroundStyle(WidgetTheme.secondary)
+                    .padding(.bottom, 5)
+
+                    ForEach(snapshot.prayers) { prayer in
+                        HStack(spacing: 7) {
+                            Image(systemName: prayer.symbolName)
+                                .frame(width: 17)
+                                .foregroundStyle(prayer.isNext ? WidgetTheme.accent : WidgetTheme.secondary)
+                            Text(prayer.name)
+                                .foregroundStyle(prayer.isNext ? WidgetTheme.accent : WidgetTheme.secondary)
+                            Spacer(minLength: 4)
+                            Text(WidgetTimeFormatter.time(prayer.time, timezoneIdentifier: snapshot.timeZoneIdentifier))
+                                .foregroundStyle(prayer.isNext ? WidgetTheme.accent : WidgetTheme.secondary)
+                                .monospacedDigit()
+                        }
+                        .font(.caption)
+                        .fontWeight(prayer.isNext ? .semibold : .regular)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 4)
+
+                        if prayer.id != snapshot.prayers.last?.id {
+                            Rectangle()
+                                .fill(WidgetTheme.divider)
+                                .frame(height: 1)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity)
+            } else {
+                Text("Open Salah to load prayer times")
+                    .font(.caption)
+                    .foregroundStyle(WidgetTheme.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .padding(16)
     }
 }
 
@@ -61,8 +258,8 @@ struct SalahWidgets: Widget {
     var body: some WidgetConfiguration {
         AppIntentConfiguration(kind: kind, intent: ConfigurationAppIntent.self, provider: Provider()) { entry in
             SalahWidgetsEntryView(entry: entry)
-                .containerBackground(.fill.tertiary, for: .widget)
         }
+        .supportedFamilies([.systemSmall, .systemMedium])
     }
 }
 
@@ -83,6 +280,12 @@ extension ConfigurationAppIntent {
 #Preview(as: .systemSmall) {
     SalahWidgets()
 } timeline: {
-    SimpleEntry(date: .now, configuration: .smiley)
-    SimpleEntry(date: .now, configuration: .starEyes)
+    SimpleEntry(date: .now, configuration: .smiley, snapshot: nil)
+    SimpleEntry(date: .now, configuration: .starEyes, snapshot: nil)
+}
+
+#Preview(as: .systemMedium) {
+    SalahWidgets()
+} timeline: {
+    SimpleEntry(date: .now, configuration: .smiley, snapshot: nil)
 }

--- a/SalahWidgets/SalahWidgets.swift
+++ b/SalahWidgets/SalahWidgets.swift
@@ -1,0 +1,88 @@
+//
+//  SalahWidgets.swift
+//  SalahWidgets
+//
+//  Created by Kazi Tanjim Shakib on 27/7/26.
+//
+
+import WidgetKit
+import SwiftUI
+
+struct Provider: AppIntentTimelineProvider {
+    func placeholder(in context: Context) -> SimpleEntry {
+        SimpleEntry(date: Date(), configuration: ConfigurationAppIntent())
+    }
+
+    func snapshot(for configuration: ConfigurationAppIntent, in context: Context) async -> SimpleEntry {
+        SimpleEntry(date: Date(), configuration: configuration)
+    }
+    
+    func timeline(for configuration: ConfigurationAppIntent, in context: Context) async -> Timeline<SimpleEntry> {
+        var entries: [SimpleEntry] = []
+
+        // Generate a timeline consisting of five entries an hour apart, starting from the current date.
+        let currentDate = Date()
+        for hourOffset in 0 ..< 5 {
+            let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate)!
+            let entry = SimpleEntry(date: entryDate, configuration: configuration)
+            entries.append(entry)
+        }
+
+        return Timeline(entries: entries, policy: .atEnd)
+    }
+
+//    func relevances() async -> WidgetRelevances<ConfigurationAppIntent> {
+//        // Generate a list containing the contexts this widget is relevant in.
+//    }
+}
+
+struct SimpleEntry: TimelineEntry {
+    let date: Date
+    let configuration: ConfigurationAppIntent
+}
+
+struct SalahWidgetsEntryView : View {
+    var entry: Provider.Entry
+
+    var body: some View {
+        VStack {
+            Text("Time:")
+            Text(entry.date, style: .time)
+
+            Text("Favorite Emoji:")
+            Text(entry.configuration.favoriteEmoji)
+        }
+    }
+}
+
+struct SalahWidgets: Widget {
+    let kind: String = "SalahWidgets"
+
+    var body: some WidgetConfiguration {
+        AppIntentConfiguration(kind: kind, intent: ConfigurationAppIntent.self, provider: Provider()) { entry in
+            SalahWidgetsEntryView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+    }
+}
+
+extension ConfigurationAppIntent {
+    fileprivate static var smiley: ConfigurationAppIntent {
+        let intent = ConfigurationAppIntent()
+        intent.favoriteEmoji = "😀"
+        return intent
+    }
+    
+    fileprivate static var starEyes: ConfigurationAppIntent {
+        let intent = ConfigurationAppIntent()
+        intent.favoriteEmoji = "🤩"
+        return intent
+    }
+}
+
+#Preview(as: .systemSmall) {
+    SalahWidgets()
+} timeline: {
+    SimpleEntry(date: .now, configuration: .smiley)
+    SimpleEntry(date: .now, configuration: .starEyes)
+}

--- a/SalahWidgets/SalahWidgets.swift
+++ b/SalahWidgets/SalahWidgets.swift
@@ -59,6 +59,8 @@ struct SalahWidgetsEntryView : View {
             switch family {
             case .systemMedium:
                 MediumWidgetView(snapshot: entry.snapshot)
+            case .systemLarge:
+                LargeWidgetView(snapshot: entry.snapshot)
             default:
                 SmallWidgetView(snapshot: entry.snapshot)
             }
@@ -156,29 +158,32 @@ private struct MediumWidgetView: View {
     let snapshot: WidgetSnapshot?
 
     var body: some View {
-        HStack(spacing: 14) {
+        HStack(spacing: 10) {
             if let snapshot, let next = snapshot.nextPrayer {
                 VStack(alignment: .leading, spacing: 0) {
-                    HStack(spacing: 6) {
+                    HStack(spacing: 5) {
                         Image(systemName: "calendar")
+                            .font(.caption)
                             .foregroundStyle(WidgetTheme.accent)
                         VStack(alignment: .leading, spacing: 1) {
                             Text(snapshot.gregorianSummary)
-                                .font(.caption.weight(.semibold))
+                                .font(.caption2.weight(.semibold))
+                                .lineLimit(1)
                             Text(snapshot.hijriSummary)
                                 .font(.caption2)
                                 .foregroundStyle(WidgetTheme.secondary)
+                                .lineLimit(1)
                         }
                     }
 
-                    Spacer(minLength: 12)
+                    Spacer(minLength: 5)
 
                     Text("NEXT PRAYER")
                         .font(.caption2.weight(.semibold))
                         .tracking(1.1)
                         .foregroundStyle(WidgetTheme.accent)
                     Text(next.name)
-                        .font(.system(size: 36, weight: .medium, design: .serif))
+                        .font(.system(size: 31, weight: .medium, design: .serif))
                         .foregroundStyle(WidgetTheme.primary)
                         .lineLimit(1)
                     HStack(alignment: .firstTextBaseline, spacing: 4) {
@@ -186,14 +191,14 @@ private struct MediumWidgetView: View {
                         Text(next.time, style: .timer)
                             .monospacedDigit()
                     }
-                    .font(.headline.weight(.semibold))
+                    .font(.subheadline.weight(.semibold))
                     .foregroundStyle(WidgetTheme.accent)
 
-                    Spacer(minLength: 8)
+                    Spacer(minLength: 4)
 
                     HStack(spacing: 8) {
                         Image(systemName: "moon.stars.fill")
-                            .font(.title2)
+                            .font(.title3)
                         Image(systemName: "building.columns.fill")
                             .font(.title3)
                             .opacity(0.35)
@@ -209,29 +214,35 @@ private struct MediumWidgetView: View {
                 VStack(spacing: 0) {
                     HStack(spacing: 5) {
                         Spacer()
-                        Text("Updated (WidgetTimeFormatter.time(snapshot.updatedAt, timezoneIdentifier: snapshot.timeZoneIdentifier))")
+                        Text("Updated \(WidgetTimeFormatter.time(snapshot.updatedAt, timezoneIdentifier: snapshot.timeZoneIdentifier))")
                         Image(systemName: "arrow.clockwise")
                     }
-                    .font(.caption2)
+                    .font(.system(size: 9))
                     .foregroundStyle(WidgetTheme.secondary)
-                    .padding(.bottom, 5)
+                    .frame(height: 12)
+                    .padding(.bottom, 1)
 
                     ForEach(snapshot.prayers) { prayer in
-                        HStack(spacing: 7) {
+                        HStack(spacing: 5) {
                             Image(systemName: prayer.symbolName)
-                                .frame(width: 17)
+                                .font(.system(size: 11))
+                                .frame(width: 15)
                                 .foregroundStyle(prayer.isNext ? WidgetTheme.accent : WidgetTheme.secondary)
                             Text(prayer.name)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.75)
                                 .foregroundStyle(prayer.isNext ? WidgetTheme.accent : WidgetTheme.secondary)
                             Spacer(minLength: 4)
                             Text(WidgetTimeFormatter.time(prayer.time, timezoneIdentifier: snapshot.timeZoneIdentifier))
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.75)
                                 .foregroundStyle(prayer.isNext ? WidgetTheme.accent : WidgetTheme.secondary)
                                 .monospacedDigit()
                         }
-                        .font(.caption)
+                        .font(.caption2)
                         .fontWeight(prayer.isNext ? .semibold : .regular)
                         .frame(maxWidth: .infinity)
-                        .padding(.vertical, 4)
+                        .frame(height: 19)
 
                         if prayer.id != snapshot.prayers.last?.id {
                             Rectangle()
@@ -248,7 +259,85 @@ private struct MediumWidgetView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
-        .padding(16)
+        .padding(12)
+    }
+}
+
+private struct LargeWidgetView: View {
+    let snapshot: WidgetSnapshot?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let snapshot, let next = snapshot.nextPrayer {
+                HStack(spacing: 8) {
+                    Image(systemName: "calendar")
+                        .font(.caption)
+                        .foregroundStyle(WidgetTheme.accent)
+                        .padding(7)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(WidgetTheme.accent.opacity(0.7), lineWidth: 1)
+                        )
+                    Text(snapshot.hijriSummary)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(WidgetTheme.secondary)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 14)
+
+                Text("NEXT PRAYER")
+                    .font(.caption2.weight(.semibold))
+                    .tracking(1.1)
+                    .foregroundStyle(WidgetTheme.accent)
+                Text(next.name)
+                    .font(.system(size: 36, weight: .medium, design: .serif))
+                    .foregroundStyle(WidgetTheme.primary)
+                    .lineLimit(1)
+                HStack(alignment: .firstTextBaseline, spacing: 4) {
+                    Text("in")
+                    Text(next.time, style: .timer)
+                        .monospacedDigit()
+                }
+                .font(.headline.weight(.semibold))
+                .foregroundStyle(WidgetTheme.accent)
+
+                Spacer(minLength: 14)
+
+                Rectangle()
+                    .fill(WidgetTheme.divider)
+                    .frame(height: 1)
+                    .padding(.bottom, 8)
+
+                VStack(spacing: 0) {
+                    ForEach(snapshot.prayers) { prayer in
+                        HStack(spacing: 9) {
+                            Image(systemName: prayer.symbolName)
+                                .font(.caption)
+                                .frame(width: 17)
+                                .foregroundStyle(prayer.isNext ? WidgetTheme.accent : WidgetTheme.secondary)
+                            Text(prayer.name)
+                                .fontWeight(prayer.isNext ? .semibold : .regular)
+                                .foregroundStyle(prayer.isNext ? WidgetTheme.accent : WidgetTheme.primary)
+                                .lineLimit(1)
+                            Spacer(minLength: 8)
+                            Text(WidgetTimeFormatter.time(prayer.time, timezoneIdentifier: snapshot.timeZoneIdentifier))
+                                .font(.subheadline.monospacedDigit())
+                                .fontWeight(prayer.isNext ? .semibold : .regular)
+                                .foregroundStyle(prayer.isNext ? WidgetTheme.accent : WidgetTheme.primary)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 30)
+                    }
+                }
+            } else {
+                Text("Open Salah to load prayer times")
+                    .font(.subheadline)
+                    .foregroundStyle(WidgetTheme.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+            }
+        }
+        .padding(20)
     }
 }
 
@@ -259,7 +348,7 @@ struct SalahWidgets: Widget {
         AppIntentConfiguration(kind: kind, intent: ConfigurationAppIntent.self, provider: Provider()) { entry in
             SalahWidgetsEntryView(entry: entry)
         }
-        .supportedFamilies([.systemSmall, .systemMedium])
+        .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
     }
 }
 
@@ -285,6 +374,12 @@ extension ConfigurationAppIntent {
 }
 
 #Preview(as: .systemMedium) {
+    SalahWidgets()
+} timeline: {
+    SimpleEntry(date: .now, configuration: .smiley, snapshot: nil)
+}
+
+#Preview(as: .systemLarge) {
     SalahWidgets()
 } timeline: {
     SimpleEntry(date: .now, configuration: .smiley, snapshot: nil)

--- a/SalahWidgets/SalahWidgetsBundle.swift
+++ b/SalahWidgets/SalahWidgetsBundle.swift
@@ -1,0 +1,18 @@
+//
+//  SalahWidgetsBundle.swift
+//  SalahWidgets
+//
+//  Created by Kazi Tanjim Shakib on 27/7/26.
+//
+
+import WidgetKit
+import SwiftUI
+
+@main
+struct SalahWidgetsBundle: WidgetBundle {
+    var body: some Widget {
+        SalahWidgets()
+        SalahWidgetsControl()
+        SalahWidgetsLiveActivity()
+    }
+}

--- a/SalahWidgets/SalahWidgetsControl.swift
+++ b/SalahWidgets/SalahWidgetsControl.swift
@@ -1,0 +1,77 @@
+//
+//  SalahWidgetsControl.swift
+//  SalahWidgets
+//
+//  Created by Kazi Tanjim Shakib on 27/7/26.
+//
+
+import AppIntents
+import SwiftUI
+import WidgetKit
+
+struct SalahWidgetsControl: ControlWidget {
+    static let kind: String = "MahiAlJawad.SalahiOS.SalahWidgets"
+
+    var body: some ControlWidgetConfiguration {
+        AppIntentControlConfiguration(
+            kind: Self.kind,
+            provider: Provider()
+        ) { value in
+            ControlWidgetToggle(
+                "Start Timer",
+                isOn: value.isRunning,
+                action: StartTimerIntent(value.name)
+            ) { isRunning in
+                Label(isRunning ? "On" : "Off", systemImage: "timer")
+            }
+        }
+        .displayName("Timer")
+        .description("A an example control that runs a timer.")
+    }
+}
+
+extension SalahWidgetsControl {
+    struct Value {
+        var isRunning: Bool
+        var name: String
+    }
+
+    struct Provider: AppIntentControlValueProvider {
+        func previewValue(configuration: TimerConfiguration) -> Value {
+            SalahWidgetsControl.Value(isRunning: false, name: configuration.timerName)
+        }
+
+        func currentValue(configuration: TimerConfiguration) async throws -> Value {
+            let isRunning = true // Check if the timer is running
+            return SalahWidgetsControl.Value(isRunning: isRunning, name: configuration.timerName)
+        }
+    }
+}
+
+struct TimerConfiguration: ControlConfigurationIntent {
+    static let title: LocalizedStringResource = "Timer Name Configuration"
+
+    @Parameter(title: "Timer Name", default: "Timer")
+    var timerName: String
+}
+
+struct StartTimerIntent: SetValueIntent {
+    static let title: LocalizedStringResource = "Start a timer"
+
+    @Parameter(title: "Timer Name")
+    var name: String
+
+    @Parameter(title: "Timer is running")
+    var value: Bool
+
+    init() {}
+
+    init(_ name: String) {
+        self.name = name
+    }
+
+    func perform() async throws -> some IntentResult {
+        // Start the timer…
+        return .result()
+    }
+}

--- a/SalahWidgets/SalahWidgetsLiveActivity.swift
+++ b/SalahWidgets/SalahWidgetsLiveActivity.swift
@@ -1,0 +1,80 @@
+//
+//  SalahWidgetsLiveActivity.swift
+//  SalahWidgets
+//
+//  Created by Kazi Tanjim Shakib on 27/7/26.
+//
+
+import ActivityKit
+import WidgetKit
+import SwiftUI
+
+struct SalahWidgetsAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        // Dynamic stateful properties about your activity go here!
+        var emoji: String
+    }
+
+    // Fixed non-changing properties about your activity go here!
+    var name: String
+}
+
+struct SalahWidgetsLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: SalahWidgetsAttributes.self) { context in
+            // Lock screen/banner UI goes here
+            VStack {
+                Text("Hello \(context.state.emoji)")
+            }
+            .activityBackgroundTint(Color.cyan)
+            .activitySystemActionForegroundColor(Color.black)
+
+        } dynamicIsland: { context in
+            DynamicIsland {
+                // Expanded UI goes here.  Compose the expanded UI through
+                // various regions, like leading/trailing/center/bottom
+                DynamicIslandExpandedRegion(.leading) {
+                    Text("Leading")
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text("Trailing")
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    Text("Bottom \(context.state.emoji)")
+                    // more content
+                }
+            } compactLeading: {
+                Text("L")
+            } compactTrailing: {
+                Text("T \(context.state.emoji)")
+            } minimal: {
+                Text(context.state.emoji)
+            }
+            .widgetURL(URL(string: "http://www.apple.com"))
+            .keylineTint(Color.red)
+        }
+    }
+}
+
+extension SalahWidgetsAttributes {
+    fileprivate static var preview: SalahWidgetsAttributes {
+        SalahWidgetsAttributes(name: "World")
+    }
+}
+
+extension SalahWidgetsAttributes.ContentState {
+    fileprivate static var smiley: SalahWidgetsAttributes.ContentState {
+        SalahWidgetsAttributes.ContentState(emoji: "😀")
+     }
+     
+     fileprivate static var starEyes: SalahWidgetsAttributes.ContentState {
+         SalahWidgetsAttributes.ContentState(emoji: "🤩")
+     }
+}
+
+#Preview("Notification", as: .content, using: SalahWidgetsAttributes.preview) {
+   SalahWidgetsLiveActivity()
+} contentStates: {
+    SalahWidgetsAttributes.ContentState.smiley
+    SalahWidgetsAttributes.ContentState.starEyes
+}

--- a/SalahWidgets/WidgetSharedData.swift
+++ b/SalahWidgets/WidgetSharedData.swift
@@ -1,0 +1,73 @@
+import Foundation
+import WidgetKit
+
+struct WidgetPrayer: Codable, Identifiable, Sendable {
+    let name: String
+    let time: Date
+    let symbolName: String
+    let completed: Bool
+    let isNext: Bool
+
+    var id: String { name }
+}
+
+struct WidgetSnapshot: Codable, Sendable {
+    let updatedAt: Date
+    let localDayKey: String
+    let gregorianSummary: String
+    let hijriSummary: String
+    let timeZoneIdentifier: String
+    let prayers: [WidgetPrayer]
+    let nextPrayer: WidgetPrayer?
+    let tomorrowFajr: WidgetPrayer?
+}
+
+extension WidgetSnapshot {
+    func snapshot(at date: Date) -> WidgetSnapshot {
+        let next = prayers
+            .filter { $0.name != "Sunrise" && $0.time > date }
+            .min { $0.time < $1.time } ?? tomorrowFajr
+
+        let updatedPrayers = prayers.map { prayer in
+            WidgetPrayer(
+                name: prayer.name,
+                time: prayer.time,
+                symbolName: prayer.symbolName,
+                completed: prayer.completed,
+                isNext: next?.name == prayer.name && next?.time == prayer.time
+            )
+        }
+
+        return WidgetSnapshot(
+            updatedAt: updatedAt,
+            localDayKey: localDayKey,
+            gregorianSummary: gregorianSummary,
+            hijriSummary: hijriSummary,
+            timeZoneIdentifier: timeZoneIdentifier,
+            prayers: updatedPrayers,
+            nextPrayer: next,
+            tomorrowFajr: tomorrowFajr
+        )
+    }
+}
+
+enum WidgetDataStore {
+    static let groupID = "group.mahiJawad_tanjimShakib.SalahiOS"
+    private static let snapshotKey = "salah.widget.snapshot"
+
+    static func save(_ snapshot: WidgetSnapshot) {
+        guard let defaults = UserDefaults(suiteName: groupID),
+              let data = try? JSONEncoder().encode(snapshot) else { return }
+
+        defaults.set(data, forKey: snapshotKey)
+        WidgetCenter.shared.reloadTimelines(ofKind: "SalahWidgets")
+    }
+
+    static func load() -> WidgetSnapshot? {
+        guard let data = UserDefaults(suiteName: groupID)?.data(forKey: snapshotKey) else {
+            return nil
+        }
+
+        return try? JSONDecoder().decode(WidgetSnapshot.self, from: data)
+    }
+}

--- a/SalahWidgetsExtension.entitlements
+++ b/SalahWidgetsExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.mahiJawad_tanjimShakib.SalahiOS</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Adds responsive Home Screen widgets for displaying prayer times and the next upcoming prayer.

## Changes

- Added small, medium, and large widget layouts.
- Added App Group data sharing between the Salah app and widget extension.
- Displays:
  - Gregorian/Hijri date
  - Next prayer
  - Live countdown
  - Prayer times including Sunrise
  - Next-prayer highlighting
- Supports rollover from Isha to the following day’s Fajr.
- Uses the app’s selected timezone and prayer settings.
- Updates widget data when prayer times load or prayer completion changes.
- Added dark navy and teal widget styling based on the provided UX references.
- Disabled Lock Screen widget families.
- Fixed widget/app bundle identifier alignment and App Group entitlements.


https://github.com/user-attachments/assets/df9d4119-fed3-445f-9098-196b6d7df373



